### PR TITLE
Добавил настройку соединения с базой при помощи переменных окружения

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,11 @@ const options = {
   autoClean: true
 };
 
+config.pgConnection.host = process.env.DBHOST || config.pgConnection.host;
+config.pgConnection.database = process.env.DBNAME || config.pgConnection.database;
+config.pgConnection.user = process.env.DBUSER || config.pgConnection.user;
+config.pgConnection.password = process.env.DBPASS || config.pgConnection.password;
+
 // parse data with connect-multiparty.
 app.use(formData.parse(options));
 // delete from the request all empty files (size == 0)
@@ -37,6 +42,7 @@ var knex = require('knex')({
   pool: { min: 0, max: 40 }
 });
 app.set('trust proxy', 1) // trust first proxy
+
 // view engine setup
 const pgSession = require('connect-pg-simple')(session);
 const pgStoreConfig = {conObject: config.pgConnection}


### PR DESCRIPTION
Эти настройки позволят:

1. Перестать хранить пароли в Git
2. При запуске приложения через systemd использовать переменные
```
[Unit]
Description=App
After=network.target

[Service]
ExecStart=/usr/bin/node /var/www/app/bin/www
Restart=always
User=root
Group=root
Environment=PATH=/usr/bin:/usr/local/bin
Environment=NODE_ENV=production
Environment=PORT=80
Environment=DBHOST=<Database Server Name>
Environment=DBNAME=<Database Name>
Environment=DBUSER=<Database User Name>
Environment=DBPASS=<Database User Password>
WorkingDirectory=/var/www/app

[Install]
WantedBy=multi-user.target
```
3. Использовать переменные окружения для настройки pm2 deployment
4. Использовать переменные окружения для настройки приложения при запуске в Docker